### PR TITLE
add reference data admin frontend

### DIFF
--- a/frontend/src/api/referenceData.api.ts
+++ b/frontend/src/api/referenceData.api.ts
@@ -1,0 +1,50 @@
+import { apiFetch } from "./client";
+import type { ReferenceDataInput, ReferenceDataItem } from "../types/referenceData";
+
+export function listReferenceDataByType(type: string): Promise<ReferenceDataItem[]> {
+  return apiFetch<ReferenceDataItem[]>(`/reference-data/${encodeURIComponent(type)}`);
+}
+
+export function createReferenceDataItem(
+  type: string,
+  input: ReferenceDataInput
+): Promise<ReferenceDataItem> {
+  return apiFetch<ReferenceDataItem>(`/reference-data/${encodeURIComponent(type)}`, {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
+
+export function updateReferenceDataItem(
+  type: string,
+  id: string,
+  input: ReferenceDataInput
+): Promise<ReferenceDataItem> {
+  return apiFetch<ReferenceDataItem>(
+    `/reference-data/${encodeURIComponent(type)}/${encodeURIComponent(id)}`,
+    {
+      method: "PUT",
+      body: JSON.stringify(input),
+    }
+  );
+}
+
+export function deactivateReferenceDataItem(
+  type: string,
+  id: string
+): Promise<ReferenceDataItem> {
+  return apiFetch<ReferenceDataItem>(
+    `/reference-data/${encodeURIComponent(type)}/${encodeURIComponent(id)}/deactivate`,
+    { method: "PATCH" }
+  );
+}
+
+export function reactivateReferenceDataItem(
+  type: string,
+  id: string
+): Promise<ReferenceDataItem> {
+  return apiFetch<ReferenceDataItem>(
+    `/reference-data/${encodeURIComponent(type)}/${encodeURIComponent(id)}/reactivate`,
+    { method: "PATCH" }
+  );
+}

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -7,6 +7,7 @@ import {
 import { PeopleListPage }   from "../features/people/PeopleListPage";
 import { CreatePersonPage } from "../features/people/CreatePersonPage";
 import { PersonDetailPage } from "../features/people/PersonDetailPage";
+import { ReferenceDataAdminPage } from "../features/reference-data/ReferenceDataAdminPage";
 
 function RouteErrorPage() {
   const error = useRouteError();
@@ -52,6 +53,7 @@ export const router = createBrowserRouter([
       { path: "people", element: <PeopleListPage /> },
       { path: "people/new", element: <CreatePersonPage /> },
       { path: "people/:id", element: <PersonDetailPage /> },
+      { path: "admin/reference-data", element: <ReferenceDataAdminPage /> },
       { path: "*", element: <NotFoundPage /> },
     ],
   },

--- a/frontend/src/features/people/PeopleListPage.tsx
+++ b/frontend/src/features/people/PeopleListPage.tsx
@@ -24,12 +24,20 @@ export function PeopleListPage() {
             </p>
           </div>
 
-          <Link
-            to="/people/new"
-            className="rounded-xl bg-gray-950 px-4 py-2 text-sm font-semibold text-white shadow-sm"
-          >
-            Add
-          </Link>
+          <div className="flex items-center gap-2">
+            <Link
+              to="/admin/reference-data"
+              className="rounded-xl border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-700 shadow-sm"
+            >
+              Admin
+            </Link>
+            <Link
+              to="/people/new"
+              className="rounded-xl bg-gray-950 px-4 py-2 text-sm font-semibold text-white shadow-sm"
+            >
+              Add
+            </Link>
+          </div>
         </div>
       </header>
 

--- a/frontend/src/features/reference-data/ReferenceDataAdminPage.test.tsx
+++ b/frontend/src/features/reference-data/ReferenceDataAdminPage.test.tsx
@@ -1,0 +1,439 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ReferenceDataAdminPage } from "./ReferenceDataAdminPage";
+import type { ReferenceDataItem } from "../../types/referenceData";
+
+const sectorRows: ReferenceDataItem[] = [
+  {
+    id: "ref-sector-mining",
+    tenantId: "default",
+    type: "sector",
+    code: "MINING",
+    label: "Mining",
+    description: "Mining operations",
+    active: true,
+    sortOrder: 10,
+  },
+];
+
+const personStatusRows: ReferenceDataItem[] = [
+  {
+    id: "ref-person-status-active",
+    tenantId: "default",
+    type: "person_status",
+    code: "ACTIVE",
+    label: "Active",
+    description: "Currently under contract",
+    active: true,
+    sortOrder: 10,
+  },
+];
+
+type FetchCall = {
+  url: string;
+  method: string;
+  body?: unknown;
+};
+
+let container: HTMLDivElement;
+let root: Root | null;
+let fetchCalls: FetchCall[];
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = null;
+  fetchCalls = [];
+});
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => {
+      root?.unmount();
+    });
+  }
+  document.body.removeChild(container);
+  vi.restoreAllMocks();
+});
+
+describe("ReferenceDataAdminPage", () => {
+  it("lists reference data filtered by type", async () => {
+    mockFetch(async (url, init) => {
+      recordFetchCall(url, init);
+
+      if (url === "/api/v1/reference-data/person_status") {
+        return jsonResponse({ data: personStatusRows });
+      }
+
+      if (url === "/api/v1/reference-data/sector") {
+        return jsonResponse({ data: sectorRows });
+      }
+
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    renderReferenceDataAdminPage();
+
+    await waitForText("Currently under contract");
+    expect(textNode("Active")).toBeTruthy();
+
+    await changeSelect("Reference data type", "sector");
+
+    await waitForText("Mining");
+    expect(fetchCalls.some((call) => call.url === "/api/v1/reference-data/sector")).toBe(true);
+  });
+
+  it("creates a reference data item", async () => {
+    mockFetch(async (url, init) => {
+      recordFetchCall(url, init);
+
+      if (url === "/api/v1/reference-data/person_status" && methodOf(init) === "GET") {
+        return jsonResponse({ data: personStatusRows });
+      }
+
+      if (url === "/api/v1/reference-data/person_status" && methodOf(init) === "POST") {
+        return jsonResponse(
+          {
+            data: {
+              id: "ref-person-status-suspended",
+              tenantId: "default",
+              type: "person_status",
+              code: "SUSPENDED",
+              label: "Suspended",
+              description: "Temporarily unavailable",
+              active: true,
+              sortOrder: 40,
+            },
+          },
+          { status: 201 }
+        );
+      }
+
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    renderReferenceDataAdminPage();
+    await waitForText("Currently under contract");
+
+    await changeInputInForm("Create Person Status", "Code", "suspended");
+    await changeInputInForm("Create Person Status", "Name", "Suspended");
+    await changeInputInForm("Create Person Status", "Description", "Temporarily unavailable");
+    await changeInputInForm("Create Person Status", "Sort Order", "40");
+    await submitFormByHeading("Create Person Status");
+
+    await waitForText("Suspended created.");
+
+    const createCall = fetchCalls.find((call) => call.method === "POST");
+    expect(createCall?.url).toBe("/api/v1/reference-data/person_status");
+    expect(createCall?.body).toMatchObject({
+      code: "suspended",
+      label: "Suspended",
+      description: "Temporarily unavailable",
+      active: true,
+      sortOrder: 40,
+      metadataJson: "",
+    });
+  });
+
+  it("updates a reference data item", async () => {
+    mockFetch(async (url, init) => {
+      recordFetchCall(url, init);
+
+      if (url === "/api/v1/reference-data/person_status" && methodOf(init) === "GET") {
+        return jsonResponse({ data: personStatusRows });
+      }
+
+      if (
+        url === "/api/v1/reference-data/person_status/ref-person-status-active" &&
+        methodOf(init) === "PUT"
+      ) {
+        return jsonResponse({
+          data: {
+            ...personStatusRows[0],
+            label: "Active Person",
+          },
+        });
+      }
+
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    renderReferenceDataAdminPage();
+    await waitForText("Currently under contract");
+
+    await clickButton("Edit");
+    await waitForText("Edit Active");
+    await changeInputInForm("Edit Active", "Name", "Active Person");
+    await submitFormByHeading("Edit Active");
+
+    await waitForText("Active Person updated.");
+
+    const updateCall = fetchCalls.find((call) => call.method === "PUT");
+    expect(updateCall?.url).toBe("/api/v1/reference-data/person_status/ref-person-status-active");
+    expect(updateCall?.body).toMatchObject({
+      code: "ACTIVE",
+      label: "Active Person",
+      description: "Currently under contract",
+      active: true,
+      sortOrder: 10,
+    });
+  });
+
+  it("deactivates and reactivates a reference data item", async () => {
+    let active = true;
+
+    mockFetch(async (url, init) => {
+      recordFetchCall(url, init);
+
+      if (url === "/api/v1/reference-data/person_status" && methodOf(init) === "GET") {
+        return jsonResponse({ data: [{ ...personStatusRows[0], active }] });
+      }
+
+      if (
+        url === "/api/v1/reference-data/person_status/ref-person-status-active/deactivate" &&
+        methodOf(init) === "PATCH"
+      ) {
+        active = false;
+        return jsonResponse({ data: { ...personStatusRows[0], active } });
+      }
+
+      if (
+        url === "/api/v1/reference-data/person_status/ref-person-status-active/reactivate" &&
+        methodOf(init) === "PATCH"
+      ) {
+        active = true;
+        return jsonResponse({ data: { ...personStatusRows[0], active } });
+      }
+
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    renderReferenceDataAdminPage();
+    await waitForText("Currently under contract");
+
+    await clickButton("Deactivate");
+    await waitForText("Active deactivated.");
+    await waitForText("Reactivate");
+    expect(fetchCalls.some((call) => call.url.endsWith("/deactivate") && call.method === "PATCH")).toBe(true);
+
+    await clickButton("Reactivate");
+    await waitForText("Active reactivated.");
+    expect(fetchCalls.some((call) => call.url.endsWith("/reactivate") && call.method === "PATCH")).toBe(true);
+  });
+
+  it("shows backend validation errors", async () => {
+    mockFetch(async (url, init) => {
+      recordFetchCall(url, init);
+
+      if (url === "/api/v1/reference-data/person_status" && methodOf(init) === "GET") {
+        return jsonResponse({ data: personStatusRows });
+      }
+
+      if (url === "/api/v1/reference-data/person_status" && methodOf(init) === "POST") {
+        return jsonResponse(
+          {
+            error: {
+              code: "validation_failed",
+              message: "Validation failed",
+              fields: {
+                label: "Name already exists for this type",
+              },
+            },
+          },
+          { status: 400 }
+        );
+      }
+
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    renderReferenceDataAdminPage();
+    await waitForText("Currently under contract");
+
+    await changeInputInForm("Create Person Status", "Code", "ACTIVE_2");
+    await changeInputInForm("Create Person Status", "Name", "Active");
+    await submitFormByHeading("Create Person Status");
+
+    await waitForText("Validation failed");
+    await waitForText("label:");
+    await waitForText("Name already exists for this type");
+  });
+});
+
+function renderReferenceDataAdminPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  const router = createMemoryRouter(
+    [{ path: "/admin/reference-data", element: <ReferenceDataAdminPage /> }],
+    { initialEntries: ["/admin/reference-data"] }
+  );
+
+  root = createRoot(container);
+
+  act(() => {
+    root?.render(
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
+    );
+  });
+}
+
+function mockFetch(
+  handler: (url: string, init?: RequestInit) => Promise<Response>
+) {
+  vi.spyOn(globalThis, "fetch").mockImplementation(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      return handler(url, init);
+    }
+  );
+}
+
+function recordFetchCall(url: string, init?: RequestInit) {
+  fetchCalls.push({
+    url,
+    method: methodOf(init),
+    body: parseBody(init?.body),
+  });
+}
+
+function methodOf(init?: RequestInit) {
+  return init?.method?.toUpperCase() ?? "GET";
+}
+
+function parseBody(body: BodyInit | null | undefined) {
+  if (typeof body !== "string") return undefined;
+
+  try {
+    return JSON.parse(body);
+  } catch {
+    return body;
+  }
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { "Content-Type": "application/json", ...(init.headers ?? {}) },
+  });
+}
+
+async function waitForText(text: string) {
+  await waitFor(() => Boolean(textNode(text)));
+}
+
+async function waitFor(assertion: () => boolean) {
+  const timeoutAt = Date.now() + 1500;
+  let lastError: unknown;
+
+  while (Date.now() < timeoutAt) {
+    try {
+      let passed = false;
+      await act(async () => {
+        passed = assertion();
+      });
+      if (passed) return;
+    } catch (error) {
+      lastError = error;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+
+  if (lastError) {
+    throw lastError;
+  }
+
+  throw new Error("Timed out waiting for assertion");
+}
+
+function textNode(text: string) {
+  return Array.from(container.querySelectorAll("*")).find((element) =>
+    element.textContent?.includes(text)
+  );
+}
+
+async function changeSelect(labelText: string, value: string) {
+  const select = controlByLabel<HTMLSelectElement>(container, labelText, "select");
+  const valueSetter = Object.getOwnPropertyDescriptor(
+    HTMLSelectElement.prototype,
+    "value"
+  )?.set;
+
+  await act(async () => {
+    valueSetter?.call(select, value);
+    select.dispatchEvent(new Event("input", { bubbles: true }));
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+}
+
+async function changeInputInForm(headingText: string, labelText: string, value: string) {
+  const form = formByHeading(headingText);
+  const input = controlByLabel<HTMLInputElement | HTMLTextAreaElement>(
+    form,
+    labelText,
+    labelText === "Metadata JSON" ? "textarea" : "input"
+  );
+  const prototype = input instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+  const valueSetter = Object.getOwnPropertyDescriptor(prototype, "value")?.set;
+
+  await act(async () => {
+    valueSetter?.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+}
+
+async function submitFormByHeading(headingText: string) {
+  const form = formByHeading(headingText);
+
+  await act(async () => {
+    form.dispatchEvent(new SubmitEvent("submit", { bubbles: true, cancelable: true }));
+  });
+}
+
+async function clickButton(name: string) {
+  const button = Array.from(container.querySelectorAll("button")).find(
+    (node) => node.textContent?.trim() === name
+  );
+  if (!button) throw new Error(`Could not find button ${name}`);
+
+  await act(async () => {
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+function formByHeading(headingText: string) {
+  const heading = Array.from(container.querySelectorAll("h2")).find((node) =>
+    node.textContent?.includes(headingText)
+  );
+  const form = heading?.closest("form");
+  if (!form) throw new Error(`Could not find form for heading ${headingText}`);
+  return form;
+}
+
+function controlByLabel<T extends HTMLElement>(
+  rootElement: ParentNode,
+  labelText: string,
+  selector: "input" | "select" | "textarea"
+): T {
+  const label = Array.from(rootElement.querySelectorAll("label")).find((node) =>
+    node.textContent?.includes(labelText)
+  );
+
+  const control = label?.querySelector(selector);
+  if (!control) {
+    throw new Error(`Could not find ${selector} for label ${labelText}`);
+  }
+
+  return control as unknown as T;
+}

--- a/frontend/src/features/reference-data/ReferenceDataAdminPage.tsx
+++ b/frontend/src/features/reference-data/ReferenceDataAdminPage.tsx
@@ -1,0 +1,406 @@
+import { FormEvent, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { ApiErrorPanel } from "../../components/ApiErrorPanel";
+import {
+  REFERENCE_DATA_TYPES,
+  type ReferenceDataInput,
+  type ReferenceDataItem,
+  referenceDataTypeLabel,
+} from "../../types/referenceData";
+import {
+  useCreateReferenceDataItem,
+  useDeactivateReferenceDataItem,
+  useReactivateReferenceDataItem,
+  useReferenceDataByType,
+  useUpdateReferenceDataItem,
+} from "./useReferenceData";
+
+const emptyForm: ReferenceDataInput = {
+  code: "",
+  label: "",
+  description: "",
+  active: true,
+  sortOrder: 0,
+  metadataJson: "",
+};
+
+export function ReferenceDataAdminPage() {
+  const [selectedType, setSelectedType] = useState<string>(REFERENCE_DATA_TYPES[0].value);
+  const [createForm, setCreateForm] = useState<ReferenceDataInput>(emptyForm);
+  const [editing, setEditing] = useState<ReferenceDataItem | null>(null);
+  const [editForm, setEditForm] = useState<ReferenceDataInput>(emptyForm);
+  const [successMessage, setSuccessMessage] = useState("");
+
+  const { data, isLoading, error } = useReferenceDataByType(selectedType);
+  const createMutation = useCreateReferenceDataItem(selectedType);
+  const updateMutation = useUpdateReferenceDataItem(selectedType);
+  const deactivateMutation = useDeactivateReferenceDataItem(selectedType);
+  const reactivateMutation = useReactivateReferenceDataItem(selectedType);
+
+  const items = useMemo(() => [...(data ?? [])].sort(bySortOrderThenLabel), [data]);
+  const actionError =
+    createMutation.error ??
+    updateMutation.error ??
+    deactivateMutation.error ??
+    reactivateMutation.error;
+
+  function handleTypeChange(type: string) {
+    setSelectedType(type);
+    setEditing(null);
+    setEditForm(emptyForm);
+    setSuccessMessage("");
+    createMutation.reset();
+    updateMutation.reset();
+    deactivateMutation.reset();
+    reactivateMutation.reset();
+  }
+
+  async function handleCreate(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSuccessMessage("");
+    createMutation.reset();
+
+    try {
+      const created = await createMutation.mutateAsync(toPayload(createForm));
+      setCreateForm(emptyForm);
+      setSuccessMessage(`${created.label} created.`);
+    } catch {
+      // Existing mutation error state is rendered by ApiErrorPanel.
+    }
+  }
+
+  function startEditing(item: ReferenceDataItem) {
+    setEditing(item);
+    setEditForm({
+      code: item.code,
+      label: item.label,
+      description: item.description ?? "",
+      active: item.active,
+      sortOrder: item.sortOrder,
+      metadataJson: item.metadataJson ?? "",
+    });
+    setSuccessMessage("");
+    updateMutation.reset();
+  }
+
+  async function handleUpdate(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!editing) return;
+
+    setSuccessMessage("");
+    updateMutation.reset();
+
+    try {
+      const updated = await updateMutation.mutateAsync({
+        id: editing.id,
+        input: toPayload(editForm),
+      });
+      setEditing(null);
+      setEditForm(emptyForm);
+      setSuccessMessage(`${updated.label} updated.`);
+    } catch {
+      // Existing mutation error state is rendered by ApiErrorPanel.
+    }
+  }
+
+  async function handleDeactivate(item: ReferenceDataItem) {
+    setSuccessMessage("");
+    deactivateMutation.reset();
+
+    try {
+      const updated = await deactivateMutation.mutateAsync(item.id);
+      setSuccessMessage(`${updated.label} deactivated.`);
+    } catch {
+      // Existing mutation error state is rendered by ApiErrorPanel.
+    }
+  }
+
+  async function handleReactivate(item: ReferenceDataItem) {
+    setSuccessMessage("");
+    reactivateMutation.reset();
+
+    try {
+      const updated = await reactivateMutation.mutateAsync(item.id);
+      setSuccessMessage(`${updated.label} reactivated.`);
+    } catch {
+      // Existing mutation error state is rendered by ApiErrorPanel.
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <header className="sticky top-0 z-10 border-b bg-white/95 px-4 py-4 backdrop-blur">
+        <div className="mx-auto flex max-w-5xl items-center justify-between gap-3">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+              Administration
+            </p>
+            <h1 className="text-xl font-bold text-gray-950">Reference Data</h1>
+            <p className="text-sm text-gray-500">
+              Manage tenant-ready Collaborator and Person dropdown values.
+            </p>
+          </div>
+
+          <Link className="text-sm font-semibold text-gray-700 underline" to="/people">
+            Back to People
+          </Link>
+        </div>
+      </header>
+
+      <section className="mx-auto max-w-5xl space-y-4 p-4">
+        {successMessage && (
+          <div role="status" className="rounded-2xl border border-green-200 bg-green-50 p-4 text-sm font-medium text-green-800">
+            {successMessage}
+          </div>
+        )}
+
+        <ApiErrorPanel error={error ?? actionError} />
+
+        <section className="rounded-2xl border bg-white p-4 shadow-sm">
+          <label className="block text-sm font-semibold text-gray-700">
+            Reference data type
+            <select
+              className="mt-2 block w-full rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm"
+              value={selectedType}
+              onChange={(event) => handleTypeChange(event.target.value)}
+            >
+              {REFERENCE_DATA_TYPES.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </section>
+
+        <section className="grid gap-4 lg:grid-cols-[1fr_2fr]">
+          <form className="rounded-2xl border bg-white p-4 shadow-sm" onSubmit={handleCreate}>
+            <h2 className="text-lg font-semibold text-gray-950">
+              Create {singularReferenceDataTypeLabel(selectedType)}
+            </h2>
+            <ReferenceDataFields value={createForm} onChange={setCreateForm} />
+            <button
+              className="mt-4 w-full rounded-xl bg-gray-950 px-4 py-2 text-sm font-semibold text-white disabled:opacity-60"
+              disabled={createMutation.isPending}
+              type="submit"
+            >
+              {createMutation.isPending ? "Creating..." : "Create Item"}
+            </button>
+          </form>
+
+          <section className="rounded-2xl border bg-white p-4 shadow-sm">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <h2 className="text-lg font-semibold text-gray-950">
+                  {referenceDataTypeLabel(selectedType)}
+                </h2>
+                <p className="text-sm text-gray-500">
+                  Values are unique within tenant, type, code, and name/label.
+                </p>
+              </div>
+              <span className="rounded-full bg-gray-100 px-3 py-1 text-xs font-semibold text-gray-700">
+                {items.length} items
+              </span>
+            </div>
+
+            {isLoading && <p className="mt-4 text-sm text-gray-500">Loading reference data...</p>}
+
+            {!isLoading && items.length === 0 && (
+              <p className="mt-4 rounded-xl border border-dashed p-4 text-center text-sm text-gray-500">
+                No reference data found for this type.
+              </p>
+            )}
+
+            {!isLoading && items.length > 0 && (
+              <div className="mt-4 overflow-hidden rounded-xl border">
+                <table className="w-full text-left text-sm">
+                  <thead className="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
+                    <tr>
+                      <th className="p-3">Code</th>
+                      <th className="p-3">Name</th>
+                      <th className="p-3">Sort</th>
+                      <th className="p-3">Status</th>
+                      <th className="p-3 text-right">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y">
+                    {items.map((item) => (
+                      <tr key={item.id}>
+                        <td className="p-3 font-mono text-xs">{item.code}</td>
+                        <td className="p-3">
+                          <div className="font-medium text-gray-950">{item.label}</div>
+                          {item.description && (
+                            <div className="text-xs text-gray-500">{item.description}</div>
+                          )}
+                        </td>
+                        <td className="p-3">{item.sortOrder}</td>
+                        <td className="p-3">
+                          <StatusBadge active={item.active} />
+                        </td>
+                        <td className="p-3">
+                          <div className="flex justify-end gap-2">
+                            <button
+                              className="rounded-lg border px-3 py-1 text-xs font-semibold"
+                              onClick={() => startEditing(item)}
+                              type="button"
+                            >
+                              Edit
+                            </button>
+                            {item.active ? (
+                              <button
+                                className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-800"
+                                onClick={() => handleDeactivate(item)}
+                                type="button"
+                              >
+                                Deactivate
+                              </button>
+                            ) : (
+                              <button
+                                className="rounded-lg border border-green-200 bg-green-50 px-3 py-1 text-xs font-semibold text-green-800"
+                                onClick={() => handleReactivate(item)}
+                                type="button"
+                              >
+                                Reactivate
+                              </button>
+                            )}
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+        </section>
+
+        {editing && (
+          <form className="rounded-2xl border bg-white p-4 shadow-sm" onSubmit={handleUpdate}>
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="text-lg font-semibold text-gray-950">Edit {editing.label}</h2>
+              <button
+                className="rounded-lg border px-3 py-1 text-xs font-semibold"
+                onClick={() => setEditing(null)}
+                type="button"
+              >
+                Cancel
+              </button>
+            </div>
+            <ReferenceDataFields value={editForm} onChange={setEditForm} />
+            <button
+              className="mt-4 rounded-xl bg-gray-950 px-4 py-2 text-sm font-semibold text-white disabled:opacity-60"
+              disabled={updateMutation.isPending}
+              type="submit"
+            >
+              {updateMutation.isPending ? "Saving..." : "Save Changes"}
+            </button>
+          </form>
+        )}
+      </section>
+    </main>
+  );
+}
+
+function ReferenceDataFields({
+  value,
+  onChange,
+}: {
+  value: ReferenceDataInput;
+  onChange: (value: ReferenceDataInput) => void;
+}) {
+  return (
+    <div className="mt-4 grid gap-3 sm:grid-cols-2">
+      <label className="block text-sm font-semibold text-gray-700">
+        Code
+        <input
+          className="mt-1 block w-full rounded-xl border border-gray-300 px-3 py-2 text-sm"
+          value={value.code}
+          onChange={(event) => onChange({ ...value, code: event.target.value })}
+        />
+      </label>
+
+      <label className="block text-sm font-semibold text-gray-700">
+        Name
+        <input
+          className="mt-1 block w-full rounded-xl border border-gray-300 px-3 py-2 text-sm"
+          value={value.label}
+          onChange={(event) => onChange({ ...value, label: event.target.value })}
+        />
+      </label>
+
+      <label className="block text-sm font-semibold text-gray-700 sm:col-span-2">
+        Description
+        <input
+          className="mt-1 block w-full rounded-xl border border-gray-300 px-3 py-2 text-sm"
+          value={value.description ?? ""}
+          onChange={(event) => onChange({ ...value, description: event.target.value })}
+        />
+      </label>
+
+      <label className="block text-sm font-semibold text-gray-700">
+        Sort Order
+        <input
+          className="mt-1 block w-full rounded-xl border border-gray-300 px-3 py-2 text-sm"
+          type="number"
+          value={value.sortOrder}
+          onChange={(event) =>
+            onChange({ ...value, sortOrder: Number(event.target.value || 0) })
+          }
+        />
+      </label>
+
+      <label className="flex items-center gap-2 self-end text-sm font-semibold text-gray-700">
+        <input
+          checked={value.active ?? true}
+          onChange={(event) => onChange({ ...value, active: event.target.checked })}
+          type="checkbox"
+        />
+        Active
+      </label>
+
+      <label className="block text-sm font-semibold text-gray-700 sm:col-span-2">
+        Metadata JSON
+        <textarea
+          className="mt-1 block min-h-20 w-full rounded-xl border border-gray-300 px-3 py-2 text-sm"
+          value={value.metadataJson ?? ""}
+          onChange={(event) => onChange({ ...value, metadataJson: event.target.value })}
+        />
+      </label>
+    </div>
+  );
+}
+
+function StatusBadge({ active }: { active: boolean }) {
+  return (
+    <span
+      className={`rounded-full px-3 py-1 text-xs font-semibold ${
+        active ? "bg-green-100 text-green-800" : "bg-gray-100 text-gray-600"
+      }`}
+    >
+      {active ? "Active" : "Inactive"}
+    </span>
+  );
+}
+
+function singularReferenceDataTypeLabel(type: string) {
+  const label = referenceDataTypeLabel(type);
+  if (label.endsWith("Statuses")) return label.replace("Statuses", "Status");
+  if (label.endsWith("ies")) return `${label.slice(0, -3)}y`;
+  if (label.endsWith("s")) return label.slice(0, -1);
+  return label;
+}
+
+function bySortOrderThenLabel(a: ReferenceDataItem, b: ReferenceDataItem) {
+  return a.sortOrder - b.sortOrder || a.label.localeCompare(b.label);
+}
+
+function toPayload(input: ReferenceDataInput): ReferenceDataInput {
+  return {
+    code: input.code.trim(),
+    label: input.label.trim(),
+    description: input.description?.trim() ?? "",
+    active: input.active ?? true,
+    sortOrder: input.sortOrder,
+    metadataJson: input.metadataJson?.trim() ?? "",
+  };
+}

--- a/frontend/src/features/reference-data/useReferenceData.ts
+++ b/frontend/src/features/reference-data/useReferenceData.ts
@@ -1,0 +1,62 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  createReferenceDataItem,
+  deactivateReferenceDataItem,
+  listReferenceDataByType,
+  reactivateReferenceDataItem,
+  updateReferenceDataItem,
+} from "../../api/referenceData.api";
+import type { ReferenceDataInput } from "../../types/referenceData";
+
+export function useReferenceDataByType(type: string) {
+  return useQuery({
+    queryKey: ["reference-data", type],
+    queryFn: () => listReferenceDataByType(type),
+    enabled: Boolean(type),
+  });
+}
+
+export function useCreateReferenceDataItem(type: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input: ReferenceDataInput) => createReferenceDataItem(type, input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["reference-data", type] });
+    },
+  });
+}
+
+export function useUpdateReferenceDataItem(type: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, input }: { id: string; input: ReferenceDataInput }) =>
+      updateReferenceDataItem(type, id, input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["reference-data", type] });
+    },
+  });
+}
+
+export function useDeactivateReferenceDataItem(type: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => deactivateReferenceDataItem(type, id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["reference-data", type] });
+    },
+  });
+}
+
+export function useReactivateReferenceDataItem(type: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => reactivateReferenceDataItem(type, id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["reference-data", type] });
+    },
+  });
+}

--- a/frontend/src/types/referenceData.ts
+++ b/frontend/src/types/referenceData.ts
@@ -1,0 +1,35 @@
+export const REFERENCE_DATA_TYPES = [
+  { value: "person_status", label: "Person Statuses" },
+  { value: "collaborator_status", label: "Collaborator Statuses" },
+  { value: "method", label: "Payment Methods" },
+  { value: "sector", label: "Sectors" },
+  { value: "location", label: "Locations" },
+  { value: "task", label: "Tasks" },
+] as const;
+
+export type ReferenceDataType = (typeof REFERENCE_DATA_TYPES)[number]["value"];
+
+export type ReferenceDataItem = {
+  id: string;
+  tenantId: string;
+  type: string;
+  code: string;
+  label: string;
+  description?: string;
+  active: boolean;
+  sortOrder: number;
+  metadataJson?: string;
+};
+
+export type ReferenceDataInput = {
+  code: string;
+  label: string;
+  description?: string;
+  active?: boolean;
+  sortOrder: number;
+  metadataJson?: string;
+};
+
+export function referenceDataTypeLabel(type: string) {
+  return REFERENCE_DATA_TYPES.find((option) => option.value === type)?.label ?? type;
+}


### PR DESCRIPTION
Completed checklist:

[x] Add frontend reference-data API client methods
[x] Add React Query hooks for reference data
[x] Add administrator reference-data page
[x] List reference data grouped or filtered by type
[x] Create reference data item
[x] Update reference data item
[x] Deactivate reference data item
[x] Reactivate reference data item
[x] Show backend validation errors
[x] Frontend tests for reference-data admin CRUD