### PR TITLE
development <-- Bite 18F.2 — Authorization admin E2E after authenticated session support (#337)

### DIFF
--- a/backend/internal/authz/admin.go
+++ b/backend/internal/authz/admin.go
@@ -390,7 +390,7 @@ func (s *GORMStore) grantsForActor(ctx context.Context, actorID string) ([]Actor
 	if err := s.database.WithContext(ctx).
 		Model(&AuthzActorRoleGrant{}).
 		Joins("JOIN authz_roles ON authz_roles.id = authz_actor_role_grants.role_id").
-		Where("authz_actor_role_grants.actor_id = ?", actorID).
+		Where("authz_actor_role_grants.actor_id = ? AND authz_actor_role_grants.active = ?", actorID, true).
 		Order("authz_roles.code ASC, authz_actor_role_grants.tenant_id ASC").
 		Select("authz_actor_role_grants.id AS id, authz_actor_role_grants.actor_id AS actor_id, authz_actor_role_grants.role_id AS role_id, authz_roles.code AS role_code, authz_actor_role_grants.tenant_id AS tenant_id, authz_roles.scope_type AS scope_type, authz_actor_role_grants.active AS active").
 		Scan(&rows).Error; err != nil {

--- a/backend/internal/authz/handler_test.go
+++ b/backend/internal/authz/handler_test.go
@@ -95,6 +95,22 @@ func TestAuthzAdminCanCreateActorGrantRoleAndRevokeGrant(t *testing.T) {
 	if actor.HasPermission(PermissionLedgerReceiptsReturn) {
 		t.Fatalf("expected revoked actor to lose expense operator permissions")
 	}
+
+	actorsResp := doAuthzRequest(t, app, http.MethodGet, "/api/v1/authz/actors", nil, headers)
+	if actorsResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected actors status 200 after revoke, got %d", actorsResp.StatusCode)
+	}
+	actors := decodeData[[]ActorResponse](t, actorsResp)
+	for _, listedActor := range actors {
+		if listedActor.ID != created.ID {
+			continue
+		}
+		if len(listedActor.RoleGrants) != 0 {
+			t.Fatalf("expected revoked grant to be hidden from actor list, got %#v", listedActor.RoleGrants)
+		}
+		return
+	}
+	t.Fatalf("expected created actor in actor list after revoke")
 }
 
 func TestAuthzAdminListsRolesPermissionsAndActors(t *testing.T) {

--- a/frontend/src/features/authz/AuthzAdminPage.tsx
+++ b/frontend/src/features/authz/AuthzAdminPage.tsx
@@ -362,7 +362,7 @@ function ActorCard({
   }
 
   return (
-    <article className="rounded-xl border p-4">
+    <article data-testid="authz-actor-card" className="rounded-xl border p-4">
       <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
         <div>
           <h3 className="font-semibold text-gray-950">{actor.actorKey}</h3>

--- a/frontend/tests/e2e/auth.spec.ts
+++ b/frontend/tests/e2e/auth.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "@playwright/test";
+import { seedBrowserAuthz } from "./support/authz";
+
+test.beforeEach(async ({ page }) => {
+  await seedBrowserAuthz(page);
+});
+
+test("admin can create an authorization actor, grant a role, and revoke it", async ({
+  page,
+}) => {
+  const suffix = uniqueSuffix();
+  const actorKey = `authz-e2e-${suffix}`;
+  const displayName = `Authz E2E ${suffix}`;
+  const grantedRole = "EXPENSE_OPERATOR";
+  const grantTenant = "default";
+
+  await page.goto("/admin/authorization");
+
+  await expect(
+    page.getByRole("heading", { name: "Authorization", exact: true }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Admin request actor" }),
+  ).toBeVisible();
+  await expect(page.getByLabel("Actor ID / key")).toHaveValue(
+    "bootstrap-admin",
+  );
+  await expect(page.getByLabel("Tenant ID")).toHaveValue("default");
+
+  await expect(
+    page.getByRole("heading", { name: "Actors", exact: true }),
+  ).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Roles" })).toBeVisible();
+  await expect(page.getByText("APPLICATION_ADMIN").first()).toBeVisible();
+  await expect(page.getByText("authz.manage").first()).toBeVisible();
+
+  await page.getByLabel("Actor key").fill(actorKey);
+  await page.getByLabel("Display name").fill(displayName);
+  await page.getByRole("button", { name: "Create Actor" }).click();
+
+  await expect(page.getByRole("status")).toContainText(`${actorKey} created.`);
+
+  const actorCard = page
+    .getByTestId("authz-actor-card")
+    .filter({
+      has: page.getByRole("heading", { name: actorKey, exact: true }),
+    });
+
+  await expect(actorCard).toBeVisible();
+  await expect(actorCard).toContainText(displayName);
+  await expect(actorCard).toContainText("No role grants.");
+
+  await actorCard.getByLabel("Role").selectOption(grantedRole);
+  await actorCard.getByLabel("Grant tenant").fill(grantTenant);
+  await actorCard.getByRole("button", { name: "Grant Role" }).click();
+
+  await expect(page.getByRole("status")).toContainText(
+    `${grantedRole} granted.`,
+  );
+  await expect(actorCard).toContainText(`${grantedRole} · ${grantTenant}`);
+
+  await actorCard.getByRole("button", { name: "Revoke" }).click();
+
+  await expect(page.getByRole("status")).toContainText(
+    `${grantedRole} revoked.`,
+  );
+  await expect(
+    actorCard.getByText(`${grantedRole} · ${grantTenant}`),
+  ).toHaveCount(0);
+  await expect(actorCard).toContainText("No role grants.");
+});
+
+function uniqueSuffix(): string {
+  return `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+}


### PR DESCRIPTION
development <-- Bite 18F.2 — Authorization admin E2E after authenticated session support (#337)